### PR TITLE
Treat `toString` and `opEquals` calls as "fallback calls"

### DIFF
--- a/test/MockToString.d
+++ b/test/MockToString.d
@@ -1,0 +1,15 @@
+import dmocks.mocks;
+
+unittest
+{
+    static class Test
+    {
+    }
+
+    auto mocker = new Mocker;
+    auto test = mocker.mock!Test;
+
+    mocker.replay;
+
+    auto toString = test.toString;
+}


### PR DESCRIPTION
Treat `toString` and `opEquals` calls as "fallback calls" that may automatically be called any number of times and are passed through, but don't show up in the output unless they've been explicitly redefined.

The point of this is that dmocks uses `toString` and `opEquals` internally, and mocks are supposed to be used to test a domain class, not parts of the dmocks library, so writing `expect(o.toString)` is bad and wrong.
However, because they are defined as a separate category of "fallback expectation" that is checked last, and separately, you can still expect them manually.