### PR TITLE
dynamic: get typename via typeof(a).stringof rather than typeid(a).toString

### DIFF
--- a/source/dmocks/action.d
+++ b/source/dmocks/action.d
@@ -137,7 +137,7 @@ class Action
         import std.format : format;
 
         enforce(
-            dynamic.canConvertTo(this._returnType),
+            dynamic.type == this._returnType || dynamic.canConvertTo(this._returnType),
             format!"Cannot set return value to '%s': expected '%s'"(dynamic.typename, this._returnType));
 
         this._returnValue = dynamic;

--- a/source/dmocks/action.d
+++ b/source/dmocks/action.d
@@ -53,7 +53,7 @@ struct Actor
             {
                 return Rope(No.pass);
             }
-            debugLog("action found, type: %s", self.action.type);
+            debugLog("action found, type: %s", self.action.typename);
 
             if (self.action.type == typeid(void delegate(ArgTypes)))
             {
@@ -65,7 +65,7 @@ struct Actor
                 import std.format : format;
 
                 throw new Error(format!"cannot call action: type %s does not match argument type %s"
-                    (self.action.type, ArgTypes.stringof));
+                    (self.action.typename, ArgTypes.stringof));
             }
         }
         else
@@ -76,7 +76,7 @@ struct Actor
             }
             else if (self.action !is null)
             {
-                debugLog("action found, type: %s", self.action.type);
+                debugLog("action found, type: %s", self.action.typename);
                 if (self.action.type == typeid(TReturn delegate(ArgTypes)))
                 {
                     return Rope(self.action.get!(TReturn delegate(ArgTypes))()(args), No.pass);
@@ -86,7 +86,7 @@ struct Actor
                     import std.format : format;
 
                     throw new Error(format!"cannot call action: type %s does not match argument type %s"
-                        (self.action.type, ArgTypes.stringof));
+                        (self.action.typename, ArgTypes.stringof));
                 }
             }
             return Rope(No.pass);
@@ -138,7 +138,7 @@ class Action
 
         enforce(
             dynamic.canConvertTo(this._returnType),
-            format!"Cannot set return value to '%s': expected '%s'"(dynamic.type, this._returnType));
+            format!"Cannot set return value to '%s': expected '%s'"(dynamic.typename, this._returnType));
 
         this._returnValue = dynamic;
     }

--- a/source/dmocks/arguments.d
+++ b/source/dmocks/arguments.d
@@ -46,7 +46,7 @@ class ArgumentsTypeMatch : ArgumentsMatch
         if (args.length != _arguments.length)
             return false;
 
-        foreach(e; zip(_arguments, args))
+        foreach (e; zip(_arguments, args))
         {
             if (e[0].type != e[1].type)
                 return false;
@@ -72,7 +72,7 @@ interface IArguments
 auto arguments(ARGS...)(ARGS args)
 {
     Dynamic[] res = new Dynamic[](ARGS.length);
-    foreach(i, arg; args)
+    foreach (i, arg; args)
     {
         res[i] = dynamic(arg);
     }

--- a/source/dmocks/arguments.d
+++ b/source/dmocks/arguments.d
@@ -58,7 +58,7 @@ class ArgumentsTypeMatch : ArgumentsMatch
 
     override string toString()
     {
-        return "("~_arguments.map!(a=>a.type.toString).join(", ")~")";
+        return "("~_arguments.map!(a=>a.typename).join(", ")~")";
     }
 }
 
@@ -81,7 +81,7 @@ auto arguments(ARGS...)(ARGS args)
 
 auto formatArguments(Dynamic[] _arguments)
 {
-    return "(" ~ _arguments.map!(a=>a.type.toString ~ " " ~ a.toString()).join(", ") ~")";
+    return "(" ~ _arguments.map!(a=>a.typename ~ " " ~ a.toString()).join(", ") ~")";
 }
 
 @("argument equality")

--- a/source/dmocks/dynamic.d
+++ b/source/dmocks/dynamic.d
@@ -161,7 +161,7 @@ class DynamicT(T) : Dynamic
             }
         }
 
-        foreach(Target; ImplicitConversionTargets!T)
+        foreach (Target; ImplicitConversionTargets!T)
         {
             if (typeid(Target) == to)
             {

--- a/source/dmocks/expectation.d
+++ b/source/dmocks/expectation.d
@@ -50,7 +50,7 @@ class CallExpectation : Expectation
         if (details)
         {
             apndr.put("\n" ~ indentation ~ "Calls: " ~ _matchedCalls.length.to!string);
-            foreach(Call call; _matchedCalls)
+            foreach (Call call; _matchedCalls)
             {
                 apndr.put("\n" ~ indentation ~ "  " ~ call.toString());
             }
@@ -117,7 +117,7 @@ class GroupExpectation : Expectation
     CallExpectation match(Call call)
     {
         // match call to expectation
-        foreach(Expectation expectation; expectations)
+        foreach (Expectation expectation; expectations)
         {
             CallExpectation e = expectation.match(call);
             if (e !is null)
@@ -135,7 +135,7 @@ class GroupExpectation : Expectation
 
     bool satisfied()
     {
-        foreach(Expectation expectation; expectations)
+        foreach (Expectation expectation; expectations)
         {
             if (!expectation.satisfied())
                 return false;
@@ -165,7 +165,7 @@ class GroupExpectation : Expectation
 
         if (details)
         {
-            foreach(Expectation expectation; expectations)
+            foreach (Expectation expectation; expectations)
             {
                 apndr.put("\n");
                 apndr.put(expectation.toString(indentation ~ "  "));

--- a/source/dmocks/qualifiers.d
+++ b/source/dmocks/qualifiers.d
@@ -12,11 +12,11 @@ QualifierMatch qualifierMatch(alias T)()
 {
     auto q = QualifierMatch();
     auto quals = qualifiers!T;
-    foreach(string name; quals)
+    foreach (string name; quals)
     {
         q._qualifiers[name] = true;
     }
-    foreach(string name; validQualifiers.filter!(a=>a !in q._qualifiers))
+    foreach (string name; validQualifiers.filter!(a=>a !in q._qualifiers))
     {
         q._qualifiers[name] = false;
     }
@@ -155,7 +155,7 @@ public void enforceQualifierNames(string[] qualifiers)
     enforce!(MocksSetupException)(qualifiers.uniq.array == qualifiers,"Qualifiers: given qualifiers are not unique: " ~ qualifiers.join(" "));
 
     // bad perf, but data is small
-    foreach(string q; qualifiers)
+    foreach (string q; qualifiers)
     {
         enforce!(MocksSetupException)(validQualifiers.canFind(q), "Qualifiers: found invalid qualifier: " ~ q);
     }
@@ -230,7 +230,7 @@ struct QualifierMatch
     {
         debugLog("QualifierMatch: match against: "~ against.join(" "));
         debugLog("state: " ~ toString());
-        foreach(string searched; against)
+        foreach (string searched; against)
         {
             const(bool)* found =  searched in _qualifiers;
             if (found is null)
@@ -239,7 +239,7 @@ struct QualifierMatch
                 return false;
         }
 
-        foreach(string key, const(bool) val; _qualifiers)
+        foreach (string key, const(bool) val; _qualifiers)
         {
             if (!val)
                 continue;

--- a/source/dmocks/repository.d
+++ b/source/dmocks/repository.d
@@ -195,7 +195,7 @@ class MockRepository
         import std.array;
         auto apndr = appender!(string);
         apndr.put("Unexpected calls(calls):\n");
-        foreach(Call ev; _unexpectedCalls)
+        foreach (Call ev; _unexpectedCalls)
         {
             apndr.put(ev.toString());
             apndr.put("\n");


### PR DESCRIPTION
Works around https://issues.dlang.org/show_bug.cgi?id=3831