### PR TITLE
don't export unittest symbol TestClass

### DIFF
--- a/source/dmocks/mocks.d
+++ b/source/dmocks/mocks.d
@@ -695,7 +695,7 @@ unittest
     assert (e !is null);
 }
 
-class TestClass
+private class TestClass
 {
     string test() { return "test"; }
     string test1() { return "test 1"; }


### PR DESCRIPTION
Fixes collision with dunit