### PR TITLE
colored call diff (basic)

### DIFF
--- a/source/dmocks/expectation.d
+++ b/source/dmocks/expectation.d
@@ -69,6 +69,28 @@ class CallExpectation : Expectation
         return apndr.data;
     }
 
+    string diffToString(Call call)
+    in (name.matches(call.name), "logic error: trying to format expectation diff to call that doesn't match it")
+    {
+        string result;
+
+        if (object != call.object)
+        {
+            result ~= yellow("(different object).");
+        }
+        result ~= call.name;
+        result ~= " ";
+        result ~= arguments.diffToString(call.arguments);
+        result ~= " ";
+        result ~= qualifiers.diffToString(call.qualifiers);
+        if (_matchedCalls.length >= repeatInterval.Max)
+        {
+            result ~= " (called too many times)";
+        }
+        result ~= "\n";
+        return result;
+    }
+
     override string toString()
     {
         return toString("");

--- a/source/dmocks/qualifiers.d
+++ b/source/dmocks/qualifiers.d
@@ -236,6 +236,12 @@ struct QualifierMatch
             (opt.length != 0 ? " (optional: " ~ opt ~ ")" : "");
     }
 
+    string diffToString(string[] against) const
+    {
+        if (matches(against)) return toString();
+        else return yellow(toString());
+    }
+
     /// returns true if all required qualifiers are present and all forbidden are absent in against array
     bool matches(string[] against) const
     {

--- a/source/dmocks/util.d
+++ b/source/dmocks/util.d
@@ -67,3 +67,26 @@ public class MocksSetupException : Exception
         super(typeof(this).stringof ~ ": " ~ msg);
     }
 }
+
+public string yellow(string text)
+{
+    if (enableAnsiEscape)
+    {
+        return "\x1b[93m" ~ text ~ "\x1b[0m";
+    }
+    return text;
+}
+
+private bool enableAnsiEscape()
+{
+    version (Posix)
+    {
+        import core.sys.posix.unistd : isatty;
+
+        return isatty(1 /* stdout */) ? true : false;
+    }
+    else
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
feature: when call doesn't match with existing expectation with the same name, provide colored diff description highlighting the failure

Instead of showing "group expectation: not fulfilled X, extra call Y" match up missing call and extra call and try to provide more detailed diff.

ping @linkrope 

TODO unittests