### PR TITLE
fix: don't try to override package methods

### DIFF
--- a/source/dmocks/method_mock.d
+++ b/source/dmocks/method_mock.d
@@ -23,7 +23,8 @@ string Methods (T, bool INHERITANCE, string methodName) () {
         {
             static if (!__traits(isStaticFunction, method) && !(methodName[0..2] == "__") && 
                        !(INHERITANCE && __traits(isFinalFunction, method)) &&
-                      __traits(getProtection, method) != "private")
+                      __traits(getProtection, method) != "private" &&
+                      __traits(getProtection, method) != "package")
                 methodBodies ~= BuildMethodOverloads!(T.stringof, methodName, overloadIndex, method, INHERITANCE);
         }
     }

--- a/test/ClassWithPackageMethod.d
+++ b/test/ClassWithPackageMethod.d
@@ -1,0 +1,17 @@
+module test.ClassWithPackageMethod;
+
+import dmocks.mocks;
+
+@("class with package method")
+unittest
+{
+    auto mocker = new Mocker;
+
+    // dmocks shouldn't try to mock foo
+    mocker.mock!Class;
+}
+
+class Class
+{
+    package void foo() { }
+}


### PR DESCRIPTION
They're probably not accessible in package dmocks.