### PR TITLE
Feature/expectT, templated typesafe expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ mocker.expect(mocked.toHash).passThrough.repeatAny;
 mocker.expect(mocked.opEquals).ignoreArgs.passThrough.repeatAny;
 ```
 
+DMocks supports typesafe expectations.
+
+dmocks stores expected parameters and return values until a call happens. This can cause issues when the
+type of the return value doesn't match the actual type returned by the function, because dmocks will only error
+once it reaches the actual method call being mocked.
+
+To alleviate this, a new form of `expect` is added, `expectT`:
+
+```d
+mocker.expectT!(obj, "method")(args).returns(value);
+```
+
+Since `expectT` statically knows the return type of the method, `returns` can make sure that it is called with
+the correct return type.
+
 Supported platforms
 ---------------------
 DMocks should build with DMD 2.078 and newer (older versions were not tested, might work aswell) on any platform DMD supports, as it contains only platform independent code. Other compilers should build the project too.

--- a/source/dmocks/mocks.d
+++ b/source/dmocks/mocks.d
@@ -196,9 +196,8 @@ public class Mocker
             auto pre = _repository.LastRecordedCallExpectation();
             methodCall();
             auto post = _repository.LastRecordedCallExpectation();
-            if (pre is post)
-                throw new InvalidOperationException(
-                        "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
+            enforce!InvalidOperationException(pre !is post,
+                    "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
             return lastCall();
         }
 
@@ -281,9 +280,8 @@ public template expectT(alias obj, string method)
         auto pre = mocker._repository.LastRecordedCallExpectation();
         __traits(getMember, obj, method)(args);
         auto post = mocker._repository.LastRecordedCallExpectation();
-        if (pre is post)
-            throw new InvalidOperationException(
-                    "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
+        enforce!InvalidOperationException(pre !is post,
+                "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
         return new typeof(return)(
                 mocker._repository.LastRecordedCallExpectation(),
                 mocker._repository.LastRecordedCall());
@@ -355,10 +353,7 @@ public class ExpectationSetup
     */
     ExpectationSetup repeat(int min, int max)
     {
-        if (min > max)
-        {
-            throw new InvalidOperationException("The specified range is invalid.");
-        }
+        enforce!InvalidOperationException(min <= max, "The specified range is invalid.");
         _expectation.repeatInterval = Interval(min, max);
         return this;
     }
@@ -457,9 +452,9 @@ public class TemplatedExpectationSetup(T)
     private Call _setUpCall;
 
     this(CallExpectation expectation, Call setUpCall)
+    in (expectation !is null, "can't create an ExpectationSetup if expectation is null")
+    in (setUpCall !is null, "can't create an ExpectationSetup if setUpCall is null")
     {
-        assert(expectation !is null, "can't create an ExpectationSetup if expectation is null");
-        assert(setUpCall !is null, "can't create an ExpectationSetup if setUpCall is null");
         _expectation = expectation;
         _setUpCall = setUpCall;
     }
@@ -487,10 +482,7 @@ public class TemplatedExpectationSetup(T)
      */
     TemplatedExpectationSetup repeat(int min, int max)
     {
-        if (min > max)
-        {
-            throw new InvalidOperationException("The specified range is invalid.");
-        }
+        enforce!InvalidOperationException(min <= max, "The specified range is invalid.");
         _expectation.repeatInterval = Interval(min, max);
         return this;
     }

--- a/source/dmocks/mocks.d
+++ b/source/dmocks/mocks.d
@@ -5,6 +5,7 @@ import dmocks.factory;
 public import dmocks.object_mock;
 import dmocks.repository;
 import dmocks.util;
+import std.traits;
 
 /++
     A class through which one creates mock objects and manages expectations about calls to their methods.
@@ -189,13 +190,6 @@ public class Mocker
          *
          * Returns an object that allows you to set various properties of the expectation,
          * such as return value, number of repetitions or matching options.
-         *
-         * Examples:
-         * ---
-         * Mocker mocker = new Mocker;
-         * Object obj = mocker.Mock!(Object);
-         * mocker.expect(obj.toString).returns("hello?");
-         * ---
          */
         ExpectationSetup expect(T)(lazy T methodCall)
         {
@@ -203,8 +197,17 @@ public class Mocker
             methodCall();
             auto post = _repository.LastRecordedCallExpectation();
             if (pre is post)
-                throw new InvalidOperationException("mocks.Mocker.expect: you did not call a method mocked by the mocker!");
+                throw new InvalidOperationException(
+                        "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
             return lastCall();
+        }
+
+        /// ditto
+        unittest
+        {
+            Mocker mocker = new Mocker;
+            Object obj = mocker.mock!(Object);
+            mocker.expect(obj.toString).returns("hello?");
         }
 
         private ExpectationSetup expectFallback(T)(lazy T methodCall)
@@ -262,6 +265,37 @@ public class Mocker
             _repository.AllowDefaults(true);
         }
     }
+}
+
+/**
+ * Record new expectation that will exactly match method called in methodCall argument
+ *
+ * Returns an object that allows you to set various properties of the expectation,
+ * such as return value, number of repetitions or matching options.
+ */
+public template expectT(alias obj, string method)
+{
+    public TemplatedExpectationSetup!(typeof(__traits(getMember, obj, method))) expectT(
+            Mocker mocker, Parameters!(typeof(__traits(getMember, obj, method))) args)
+    {
+        auto pre = mocker._repository.LastRecordedCallExpectation();
+        __traits(getMember, obj, method)(args);
+        auto post = mocker._repository.LastRecordedCallExpectation();
+        if (pre is post)
+            throw new InvalidOperationException(
+                    "mocks.Mocker.expect: you did not call a method mocked by the mocker!");
+        return new typeof(return)(
+                mocker._repository.LastRecordedCallExpectation(),
+                mocker._repository.LastRecordedCall());
+    }
+}
+
+/// ditto
+unittest
+{
+    Mocker mocker = new Mocker;
+    Object obj = mocker.mock!(Object);
+    mocker.expectT!(obj, "toString")().returns("hello?");
 }
 
 /++
@@ -400,6 +434,134 @@ public class ExpectationSetup
     * `opEquals` and `toString` are passed through automatically.
     */
     ExpectationSetup passThrough()
+    {
+        _expectation.action.passThrough = true;
+        return this;
+    }
+}
+
+public class TemplatedExpectationSetup(T)
+{
+    import dmocks.arguments;
+    import dmocks.expectation;
+    import dmocks.dynamic;
+    import dmocks.qualifiers;
+    import dmocks.call;
+
+    private alias Ret = ReturnType!T;
+
+    private alias Params = Parameters!T;
+
+    private CallExpectation _expectation;
+
+    private Call _setUpCall;
+
+    this(CallExpectation expectation, Call setUpCall)
+    {
+        assert(expectation !is null, "can't create an ExpectationSetup if expectation is null");
+        assert(setUpCall !is null, "can't create an ExpectationSetup if setUpCall is null");
+        _expectation = expectation;
+        _setUpCall = setUpCall;
+    }
+
+    /**
+     * Ignore method argument values in matching calls to this expectation.
+     */
+    TemplatedExpectationSetup ignoreArgs()
+    {
+        _expectation.arguments = new ArgumentsTypeMatch(_setUpCall.arguments, (Dynamic a, Dynamic b) => true);
+        return this;
+    }
+
+    /**
+     * Allow providing custom argument comparator for matching calls to this expectation.
+     */
+    TemplatedExpectationSetup customArgsComparator(bool delegate(Dynamic expected, Dynamic provided) del)
+    {
+        _expectation.arguments = new ArgumentsTypeMatch(_setUpCall.arguments, del);
+        return this;
+    }
+
+    /**
+     * This expectation must match to at least min number of calls and at most to max number of calls.
+     */
+    TemplatedExpectationSetup repeat(int min, int max)
+    {
+        if (min > max)
+        {
+            throw new InvalidOperationException("The specified range is invalid.");
+        }
+        _expectation.repeatInterval = Interval(min, max);
+        return this;
+    }
+
+    /**
+     * This expectation will match exactly i times.
+     */
+    TemplatedExpectationSetup repeat(int i)
+    {
+        repeat(i, i);
+        return this;
+    }
+
+    /**
+     * This expectation will match to any number of calls.
+     */
+    TemplatedExpectationSetup repeatAny()
+    {
+        return repeat(0, int.max);
+    }
+
+    /**
+     * When the method which matches this expectation is called execute the
+     * given delegate. The delegate's signature must match the signature
+     * of the called method. If it does not, an exception will be thrown.
+     * The called method will return whatever the given delegate returns.
+     * Examples:
+     * ---
+     * mocker.expect!(myObj, "myFunc")(0, null, null, 'a')
+     *     .ignoreArgs()
+     *     .action((int i, char[] s, Object o, char c) { return -1; });
+     * ---
+     */
+    TemplatedExpectationSetup action(Ret delegate(Params) action)
+    {
+        _expectation.action.action = dynamic(action);
+        return this;
+    }
+
+    /**
+     * Set the value to return when method matching this expectation is called on a mock object.
+     * Params:
+     *     value = the value to return
+     */
+    TemplatedExpectationSetup returns(Ret value)
+    {
+        _expectation.action.returnValue = dynamic(value);
+        return this;
+    }
+
+    /**
+     * When the method which matches this expectation is called,
+     * throw the given exception. If there are any
+     * actions specified (via the action method), they will not be executed.
+     */
+    TemplatedExpectationSetup throws(Exception e)
+    {
+        _expectation.action.toThrow = e;
+        return this;
+    }
+
+    /**
+     * Instead of returning or throwing a given value, pass the call through to
+     * the mocked type object. For mock***PassTo(obj) obj has to be valid for this to work.
+     *
+     * This is useful for example for enabling use of mock object in hashmaps by enabling
+     * toHash and opEquals of your class.
+     *
+     * `opEquals` and `toString` are passed through automatically.
+     */
+    TemplatedExpectationSetup passThrough()
     {
         _expectation.action.passThrough = true;
         return this;
@@ -725,6 +887,11 @@ private class TestClass
     {
         return "test 2";
     }
+
+    int test_int(int i)
+    {
+        return i;
+    }
 }
 
 @("return a value")
@@ -756,6 +923,29 @@ unittest
     mocker.expect(cl.test).repeat(0).returns("mrow?");
     mocker.replay();
     assertThrown!ExpectationViolationError(cl.test);
+}
+
+@("expect mismatched type")
+unittest
+{
+    Mocker mocker = new Mocker();
+    TestClass cl = mocker.mock!(TestClass);
+
+    void call_test(T)(T arg)
+    {
+        mocker.expectT!(cl, "test_int")(arg);
+    }
+
+    static assert(__traits(compiles, call_test(5)));
+    static assert(!__traits(compiles, call_test("string")));
+
+    void return_test(T)(T arg)
+    {
+        mocker.expectT!(cl, "test_int")(5).returns(arg);
+    }
+
+    static assert(__traits(compiles, return_test(5)));
+    static assert(!__traits(compiles, return_test("string")));
 }
 
 @("repeat single")

--- a/source/dmocks/util.d
+++ b/source/dmocks/util.d
@@ -41,14 +41,14 @@ template IsConcreteClass(T)
 
 class InvalidOperationException : Exception
 {
-    this()
+    this(string file = __FILE__, size_t line = __LINE__)
     {
-        super(typeof(this).stringof ~ "The requested operation is not valid.");
+        super(typeof(this).stringof ~ "The requested operation is not valid.", file, line);
     }
 
-    this(string msg)
+    this(string msg, string file = __FILE__, size_t line = __LINE__)
     {
-        super(typeof(this).stringof ~ msg);
+        super(typeof(this).stringof ~ msg, file, line);
     }
 }
 


### PR DESCRIPTION
Add templated expect variant.

I couldn't make it work with the same name as `expect` due to overload resolution failing.

`expectT` is a freestanding function because aliasing local objects to methods doesn't work in 2.086.1.

The copypaste duplication of `ExpectationSetup` is annoying, but I don't see how to avoid it.