### PR TITLE
reuse dshould color diff routines to compare toString

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,13 +15,19 @@
     "configurations": [
         {
             "name": "library",
-            "targetType": "library"
+            "targetType": "library",
+            "dependencies": {
+              "dshould": ">=1.3.0"
+            }
         },
         {
             "name": "unittest",
             "targetType": "executable",
             "sourcePaths": ["test"],
-            "mainSourceFile": "test/main.d"
+            "mainSourceFile": "test/main.d",
+            "dependencies": {
+              "dshould": ">=1.3.0"
+            }
         }
     ]
 }

--- a/source/dmocks/arguments.d
+++ b/source/dmocks/arguments.d
@@ -108,7 +108,23 @@ class ArgumentsTypeMatch : ArgumentsMatch
             if (e[0].type != e[1].type)
                 info ~= " " ~ yellow(format!"(but got %s)"(e[1].type));
             if (!_del(e[0], e[1]))
-                info ~= " " ~ yellow("(but action failed)");
+            {
+                if (e[0].toString() != e[1].toString())
+                {
+                    import dshould.stringcmp : oneLineDiff;
+
+                    auto diff = oneLineDiff(e[0].toString(), e[1].toString());
+                    info ~= " "
+                        ~ yellow("(but comparator failed. ")
+                        ~ format!"Info: expected.toString %s, got.toString %s"(
+                            diff.original, diff.target)
+                        ~ yellow(")");
+                }
+                else
+                {
+                    info ~= " " ~ yellow("(but comparator failed. Info: expected.toString == got.toString)");
+                }
+            }
             argInfos ~= info;
         }
         return "(" ~ argInfos.join(", ") ~ ")";


### PR DESCRIPTION
`toString` often has useful info.

Strictly speaking, I should really farm color diff out into a separate dub package.

But meh.